### PR TITLE
Fix usage of res.locals in Express 3.x

### DIFF
--- a/i18n.js
+++ b/i18n.js
@@ -135,6 +135,9 @@ i18n.prototype = {
     },
 
     setLocale: function(locale) {
+
+        if (!locale) return;
+
         if (!this.locales[locale]) {
             if (this.devMode) {
                 console.warn("Locale (" + locale + ") not found.");
@@ -218,11 +221,14 @@ i18n.prototype = {
             self = this,
             prefLocale;
 
-        accept.match(/(^|,\s*)([a-z]+)/g).forEach(function(locale) {
-            if (!prefLocale && self.locales[locale]) {
-                prefLocale = locale;
-            }
-        });
+        if (accept) {
+            accept.match(/(^|,\s*)([a-z]+)/g).forEach(function(locale) {
+                if (!prefLocale && self.locales[locale]) {
+                    prefLocale = locale;
+                }
+            });
+        }
+
 
         return prefLocale;
     },
@@ -318,7 +324,7 @@ i18n.prototype = {
 
             } else {
                 console.error('unable to write locales to file (either ' + tmp +
-                    ' or ' + target + ' are not writeable?): ', e);
+                    ' or ' + target + ' are not writeable?): ');
             }
 
         } catch (e) {


### PR DESCRIPTION
This patch is needed to work with Express 3.x, tested on 3.0.5 and 3.1.0

I'm using ejs 0.8.3 as a template engine.
