### PR TITLE
Fix bug with defaultLocale for preferredLocale.

### DIFF
--- a/i18n.js
+++ b/i18n.js
@@ -219,7 +219,7 @@ i18n.prototype = {
 
 		var accept = req.headers["accept-language"] || "",
 			self = this,
-			prefLocale = this.defaultLocale;
+			prefLocale;
 
 		(accept.match(/(^|,\s*)([a-z]+)/g) || []).forEach(function(locale) {
 			if (!prefLocale && self.locales[locale]) {
@@ -227,7 +227,7 @@ i18n.prototype = {
 			}
 		});
 
-		return prefLocale;
+		return prefLocale || this.defaultLocale;
 	},
 
 	// read locale file, translate a msg and write to fs if new


### PR DESCRIPTION
If `this.defaultLocale` exist then `prefLocale` will never be found.
