### PR TITLE
Not all languages tags can be parsed

### DIFF
--- a/i18n.js
+++ b/i18n.js
@@ -218,7 +218,7 @@ i18n.prototype = {
 		}
 
 		var accept = req.headers["accept-language"] || "",
-			regExp = /(^|,\s*)([a-z-]+)/gi,
+			regExp = /(^|,\s*)([a-z0-9-]+)/gi,
 			self = this,
 			prefLocale;
 


### PR DESCRIPTION
Spanish of Latin America has tag: es-419, that cannot be parsed by the regexp.