### PR TITLE
lower case for preferred locale

### DIFF
--- a/i18n.js
+++ b/i18n.js
@@ -223,7 +223,7 @@ i18n.prototype = {
 			prefLocale;
 
 		while ((match = regExp.exec(accept))){
-			var locale = match[2];
+			var locale = match[2].toLowerCase();
 			var parts = locale.split("-");
 
 			if (!prefLocale) {

--- a/i18n.js
+++ b/i18n.js
@@ -222,16 +222,14 @@ i18n.prototype = {
 			self = this,
 			prefLocale;
 
-		while ((match = regExp.exec(accept))){
+		while (!prefLocale && (match = regExp.exec(accept))){
 			var locale = match[2].toLowerCase();
 			var parts = locale.split("-");
 
-			if (!prefLocale) {
-				if (self.locales[locale]) {
-					prefLocale = locale;
-				} else if (parts.length > 1 && self.locales[parts[0]]) {
-					prefLocale = parts[0];
-				}
+			if (self.locales[locale]) {
+				prefLocale = locale;
+			} else if (parts.length > 1 && self.locales[parts[0]]) {
+				prefLocale = parts[0];
 			}
 		}
 

--- a/i18n.js
+++ b/i18n.js
@@ -220,6 +220,7 @@ i18n.prototype = {
 		var accept = req.headers["accept-language"] || "",
 			regExp = /(^|,\s*)([a-z-]+)/gi,
 			self = this,
+			match,
 			prefLocale;
 
 		while (!prefLocale && (match = regExp.exec(accept))){


### PR DESCRIPTION
The `preferredLocale()` function did not always return locale in lower case. This may conflict with using other functions together, such as `setLocaleFromQuery()` and `setLocaleFromCookie()`. So I changed it to return always lower case.

Also, I removed unnecessary loops. When my web browser sent `headers["accept-language"] == 'ko-KR,ko;q=0.8,en-US;q=0.6,en;q=0.4'`, the while loop in the `preferredLocale()` function looped four times even the `ko` was matched on the first loop.