### PR TITLE
Remove app.configure() from app.js, deprecated in Express 4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,31 +229,25 @@ In your app.js:
 	var express = require('express'),
 		I18n = require('i18n-2');
 
-	// Express Configuration
-	app.configure(function() {
-
-		// ...
-
-		// Attach the i18n property to the express request object
-		// And attach helper methods for use in templates
-		I18n.expressBind(app, {
-			// setup some locales - other locales default to en silently
-			locales: ['en', 'de'],
-			// change the cookie name from 'lang' to 'locale'
-			cookieName: 'locale'
-		});
-		
-		// This is how you'd set a locale from req.cookies.
-		// Don't forget to set the cookie either on the client or in your Express app.
-		app.use(function(req, res, next) {
-			req.i18n.setLocaleFromCookie();
-			next();
-		});
-
-		// Set up the rest of the Express middleware
-		app.use(app.router);
-		app.use(express.static(__dirname + '/public'));
+	// Attach the i18n property to the express request object
+	// And attach helper methods for use in templates
+	I18n.expressBind(app, {
+		// setup some locales - other locales default to en silently
+		locales: ['en', 'de'],
+		// change the cookie name from 'lang' to 'locale'
+		cookieName: 'locale'
 	});
+		
+	// This is how you'd set a locale from req.cookies.
+	// Don't forget to set the cookie either on the client or in your Express app.
+	app.use(function(req, res, next) {
+		req.i18n.setLocaleFromCookie();
+		next();
+	});
+
+	// Set up the rest of the Express middleware
+	app.use(app.router);
+	app.use(express.static(__dirname + '/public'));
 
 ### Inside Your Express View
 


### PR DESCRIPTION
http://stackoverflow.com/questions/22202232/express-has-no-method-configure-error