### PR TITLE
Fix error when req.query.lang is an array

### DIFF
--- a/i18n.js
+++ b/i18n.js
@@ -165,7 +165,7 @@ i18n.prototype = {
 			return;
 		}
 
-		var locale = req.query.lang.toLowerCase();
+		var locale = (req.query.lang+'').toLowerCase();
 
 		if (this.locales[locale]) {
 			if (this.devMode) {


### PR DESCRIPTION
If req.query.lang is an array, i18n-node-2 will try to call toLowerCase on an array making the request fail.