### PR TITLE
Convention __n for 0 and negative values

### DIFF
--- a/i18n.js
+++ b/i18n.js
@@ -125,7 +125,7 @@ i18n.prototype = {
 	__n: function(singular, plural, count) {
 		var msg = this.translate(this.locale, singular, plural);
 
-		msg = vsprintf(parseInt(count, 10) > 1 ? msg.other : msg.one, [count]);
+		msg = vsprintf(parseInt(count, 10) === 1 ? msg.one : msg.other, [count]);
 
 		if (arguments.length > 3) {
 			msg = vsprintf(msg, Array.prototype.slice.call(arguments, 3));


### PR DESCRIPTION
As ```one``` and ```other```says: Shouldn't it be plurar (other) when the value is 0 or less as well ?
Would read:
"I own 0 cats."
instead of
"I own 0 cat."