### PR TITLE
dot notation refactor

### DIFF
--- a/i18n.js
+++ b/i18n.js
@@ -13,14 +13,20 @@ var vsprintf = require("sprintf").vsprintf,
 		path = require("path");
 
 
-function dotNotation (obj, str) {
-	if (obj.hasOwnProperty(str)) {
-		return obj[str];
+function dotNotation (obj, is, value) {
+	if (typeof is === 'string') {
+		return dotNotation(obj, is.split('.'), value);
+	} else if (is.length === 1 && value !== undefined) {
+		return obj[is[0]] = value;
+	} else if (is.length === 0) {
+		return obj;
+	} else {
+		if (obj.hasOwnProperty(is[0])) {
+			return dotNotation(obj[is[0]], is.slice(1), value);
+		} else {
+			return obj[is.join('.')] = is.join('.');
+		}
 	}
-
-    return str.split(".").reduce(function(o, x) {
-    	return o[x];
-    }, obj);
 }
 
 var i18n = module.exports = function (opt) {
@@ -293,16 +299,12 @@ i18n.prototype = {
 		}
 
 		if (!this.locales[locale][singular]) {
-			this.locales[locale][singular] = plural ?
-			{ one: singular, other: plural } :
-					singular;
-
 			if (this.devMode) {
 				this.writeFile(locale);
 			}
 		}
 
-		return dotNotation(this.locales[locale], singular);
+		return dotNotation(this.locales[locale], singular, plural ? { one: singular, other: plural } : undefined);
 	},
 
 	// try reading a file


### PR DESCRIPTION
Refactored the dot notation method so that it can handle plural and assignment of keys that do not exist. This simplified the translate method as a result.