### PR TITLE
Optionally pass custom query string parameter

### DIFF
--- a/i18n.js
+++ b/i18n.js
@@ -135,6 +135,7 @@ i18n.prototype = {
 	defaultLocale: "en",
 	extension: ".js",
 	directory: "./locales",
+	queryName: "lang",
 	cookieName: "lang",
 	sessionVarName: "locale",
 	indent: "\t",
@@ -214,11 +215,11 @@ i18n.prototype = {
 	setLocaleFromQuery: function (req) {
 		req = req || this.request;
 
-		if (!req || !req.query || !req.query.lang) {
+		if (!req || !req.query || !req.query[this.queryName]) {
 			return;
 		}
 
-		var locale = (req.query.lang+'').toLowerCase();
+		var locale = req.query[this.queryName].toLowerCase();
 
 		if (this.locales[locale]) {
 			if (this.devMode) {


### PR DESCRIPTION
Works the same as setting a custom `cookieName`