### PR TITLE
Add additional MIT license metadata

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,22 @@
+(The MIT License)
+
+Copyright (c) 2011-2013 Marcus Spiegel <marcus.spiegel@gmail.com>
+Copyright (c) 2013-2015 John Resig <jeresig@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/package.json
+++ b/package.json
@@ -23,5 +23,6 @@
   },
   "scripts": {
     "test": "expresso test/*"
-  }
+  },
+  "license": "MIT"
 }


### PR DESCRIPTION
My motivation for this pull is to ensure that the attribution requirements are met for the MIT license, and to make it clear in `npm` that this code is licensed MIT, as currently npmjs.org displays `none` as the license type which is not ideal.

Making it clear that this package is licensed MIT is important, as it allows me to avoid questions from clients regarding licensing, as they can see at a glance what the license for each package is without digging into the source code.