### PR TITLE
fixed undefined issue when session is not present

### DIFF
--- a/i18n.js
+++ b/i18n.js
@@ -210,6 +210,10 @@ i18n.prototype = {
 	setLocaleFromSessionVar: function (req) {
 		req = req || this.request;
 
+		if (!req || !req.session || !req.session[this.sessionVarName]) {
+			return;
+		}
+
 		var locale = req.session[this.sessionVarName];
 
 		if (this.locales[locale]) {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "i18n-2",
   "description": "lightweight simple translation module with dynamic json storage",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "homepage": "http://github.com/jeresig/i18n-node-2",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Due to missing checks I've got an undefined error  (of ``req.session``), when using the newest version v0.6.0 with express.
Stacktrace:

````
TypeError: Cannot read property 'locale' of undefined
    at Object.i18n.setLocaleFromSessionVar (/Users/timbrust/Coding/ninja/node_modules/i18n-2/i18n.js:213:27)
    at Object.module.exports (/Users/timbrust/Coding/ninja/node_modules/i18n-2/i18n.js:84:9)
    at /Users/timbrust/Coding/ninja/node_modules/i18n-2/i18n.js:107:14
    at Layer.handle [as handle_request] (/Users/timbrust/Coding/ninja/node_modules/express/lib/router/layer.js:95:5)
    at trim_prefix (/Users/timbrust/Coding/ninja/node_modules/express/lib/router/index.js:312:13)
    at /Users/timbrust/Coding/ninja/node_modules/express/lib/router/index.js:280:7
    at Function.process_params (/Users/timbrust/Coding/ninja/node_modules/express/lib/router/index.js:330:12)
    at next (/Users/timbrust/Coding/ninja/node_modules/express/lib/router/index.js:271:10)
    at expressInit (/Users/timbrust/Coding/ninja/node_modules/express/lib/middleware/init.js:33:5)
    at Layer.handle [as handle_request] (/Users/timbrust/Coding/ninja/node_modules/express/lib/router/layer.js:95:5)
    at trim_prefix (/Users/timbrust/Coding/ninja/node_modules/express/lib/router/index.js:312:13)
    at /Users/timbrust/Coding/ninja/node_modules/express/lib/router/index.js:280:7
    at Function.process_params (/Users/timbrust/Coding/ninja/node_modules/express/lib/router/index.js:330:12)
    at next (/Users/timbrust/Coding/ninja/node_modules/express/lib/router/index.js:271:10)
    at query (/Users/timbrust/Coding/ninja/node_modules/express/lib/middleware/query.js:49:5)
    at Layer.handle [as handle_request] (/Users/timbrust/Coding/ninja/node_modules/express/lib/router/layer.js:95:5)
````