### PR TITLE
different of 'production' NODE_ENV

### DIFF
--- a/i18n.js
+++ b/i18n.js
@@ -37,7 +37,7 @@ var i18n = module.exports = function (opt) {
 	var self = this;
 
 	// Put into dev or production mode
-	this.devMode = process.env.NODE_ENV !== this.getProductionEnvName();
+	this.devMode = process.env.NODE_ENV !== this.productionEnvName;
 
 	// Copy over options
 	for (var prop in opt) {
@@ -201,10 +201,6 @@ i18n.prototype = {
 
 	getLocale: function () {
 		return this.locale;
-	},
-
-	getProductionEnvName: function () {
-		return this.productionEnvName;
 	},
 
 	isPreferredLocale: function () {

--- a/i18n.js
+++ b/i18n.js
@@ -37,7 +37,7 @@ var i18n = module.exports = function (opt) {
 	var self = this;
 
 	// Put into dev or production mode
-	this.devMode = process.env.NODE_ENV !== "production";
+	this.devMode = process.env.NODE_ENV !== this.getProductionEnvName();
 
 	// Copy over options
 	for (var prop in opt) {
@@ -141,6 +141,7 @@ i18n.prototype = {
 	directory: "./locales",
 	cookieName: "lang",
 	sessionVarName: "locale",
+	productionEnvName: "production",
 	indent: "\t",
 
 	parse: JSON.parse,
@@ -200,6 +201,10 @@ i18n.prototype = {
 
 	getLocale: function () {
 		return this.locale;
+	},
+
+	getProductionEnvName: function () {
+		return this.productionEnvName;
 	},
 
 	isPreferredLocale: function () {


### PR DESCRIPTION
We had some troubles after deploying our code on one of our production servers. The reason is trivial - different from 'production' NODE_ENV variable. I think it would be a great to have the way to set proper environment variable in options