### PR TITLE
Allow defaultLocale to be supplied with opts. #90

### DIFF
--- a/i18n.js
+++ b/i18n.js
@@ -60,7 +60,7 @@ var i18n = module.exports = function (opt) {
 			self.readFile(locale);
 		});
 
-		this.defaultLocale = opt.locales[0];
+		this.defaultLocale = opt.defaultLocale || opt.locales[0];
 	}
 
 	// Set the locale to the default locale

--- a/test/i18n.configure.js
+++ b/test/i18n.configure.js
@@ -17,6 +17,29 @@ module.exports = {
 		assert.equal('de', i18n.getLocale(), 'should return the new setting');
 	},
 
+    'check set defaultLocale when no default supplied': function () {
+        var i18n = new I18n({
+            locales: ['en', 'de'],
+            directory: './testlocales',
+            extension: '.json'
+        });
+
+        var loc = i18n.getLocale();
+        assert.equal('en', i18n.getLocale(), 'should return first locale setting from locales');
+    },
+
+    'check set defaultLocale when default supplied': function () {
+        var i18n = new I18n({
+            locales: ['en', 'de'],
+            directory: './testlocales',
+            extension: '.json',
+            defaultLocale: 'de'
+        });
+
+        var loc = i18n.getLocale();
+        assert.equal('de', i18n.getLocale(), 'should return default locale setting');
+    },
+
 	'check singular': function () {
 		var i18n = new I18n({
 			locales: ['en', 'de'],


### PR DESCRIPTION
Fixes open issue #90. There was never any support for `defaultLocale` in opts. There is now.