### PR TITLE
Change to fix webpack compile error on import

### DIFF
--- a/i18n.js
+++ b/i18n.js
@@ -210,7 +210,7 @@ i18n.prototype = {
 	setLocaleFromSessionVar: function (req) {
 		req = req || this.request;
 
-		if (!req || !req.session || !req.session[this.sessionVarName]) {		
+		if (!req || !req.session || !req.session[this.sessionVarName]) {
 			return;
 		}
 
@@ -419,7 +419,7 @@ i18n.prototype = {
 				console.log('creating locales dir in: ' + this.directory);
 			}
 
-			fs.mkdirSync(this.directory, 0755);
+			fs.mkdirSync(this.directory, 0o755);
 		}
 
 		// Initialize the locale if didn't exist already


### PR DESCRIPTION
Change `0755` fs write mode to `0o755` which is the standard way to write the permissions as an octal for node js.

Reference:
https://nodejs.org/api/fs.html#fs_fs_createwritestream_path_options

Additional:
https://stackoverflow.com/questions/39850133/node-js-how-to-create-file-with-755-permissions-with-fs-createwritestream

Otherwise leaving this unchaged causes a Webpack compile issue.
```
ERROR in ./node_modules/i18n-2/i18n.js
Module build failed: SyntaxError: Invalid number (422:32)

420 |                  }
421 |                   fs.mkdirSync(this.directory, 0755);
    |
423 |         }
424 |
425 |         // Initialize the locale if didn't exist already

```

<img width="582" alt="screen shot 2017-08-03 at 3 20 38 pm" src="https://user-images.githubusercontent.com/5892190/28944310-627711cc-785f-11e7-8d91-f8a0c720024c.png">
