### PR TITLE
Update deprecated sprintf dependency

### DIFF
--- a/i18n.js
+++ b/i18n.js
@@ -8,7 +8,7 @@
  */
 
 // dependencies
-var vsprintf = require("sprintf").vsprintf,
+var vsprintf = require("sprintf-js").vsprintf,
 		fs = require("fs"),
 		path = require("path"),
 		debugLog = require('debug')('i18n-2:log'),

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "debug": "^3.1.0",
-    "sprintf": "^0.1.5"
+    "sprintf-js": "^1.1.1"
   },
   "devDependencies": {
     "expresso": ">=0.9.2",


### PR DESCRIPTION
Hello,

As the author of `sprintf` states:

> The sprintf package is deprecated in favor of sprintf-js.
[https://www.npmjs.com/package/sprintf](url)

As this package uses it, this PR removes the sprintf dependency and adds the new sprintf implementation (`sprintf-js`). This new library's API is fully compatible with `sprintf` and all tests passed.